### PR TITLE
QR reader not pre-filling amount

### DIFF
--- a/Raiblocks.xcodeproj/project.pbxproj
+++ b/Raiblocks.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		29C30D0121079D2100DF237F /* QRCode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29C30D0021079D2100DF237F /* QRCode.swift */; };
 		510896D32053739300A5362D /* AddressParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 510896D22053739300A5362D /* AddressParser.swift */; };
 		510C39202084F3DC004DDC6B /* GenericFunctions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 510C391F2084F3DC004DDC6B /* GenericFunctions.swift */; };
 		5117F4D01FD8490800CEAE78 /* Credentials.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5117F4CF1FD8490800CEAE78 /* Credentials.swift */; };
@@ -137,6 +138,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		29C30D0021079D2100DF237F /* QRCode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QRCode.swift; sourceTree = "<group>"; };
 		415B60457C17517F10FE2D5D /* Pods-Raiblocks.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Raiblocks.release.xcconfig"; path = "Pods/Target Support Files/Pods-Raiblocks/Pods-Raiblocks.release.xcconfig"; sourceTree = "<group>"; };
 		510896D22053739300A5362D /* AddressParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddressParser.swift; sourceTree = "<group>"; };
 		510C391F2084F3DC004DDC6B /* GenericFunctions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GenericFunctions.swift; sourceTree = "<group>"; };
@@ -273,6 +275,7 @@
 		51203A3B1FE1ECF700CD7D79 /* Models */ = {
 			isa = PBXGroup;
 			children = (
+				29C30D0021079D2100DF237F /* QRCode.swift */,
 				517FA64C1FE1D1DB00FE04B6 /* Address.swift */,
 				51394038202B64BB0073B90F /* ExchaingePairs.swift */,
 				5117F4CF1FD8490800CEAE78 /* Credentials.swift */,
@@ -852,6 +855,7 @@
 				5174E8F9200FA6CF00DE86A0 /* PriceService.swift in Sources */,
 				519B4D801FD74955006B7B6E /* RaiCore.m in Sources */,
 				51CD153F1FF854B5004102A2 /* SendKeyboardButton.swift in Sources */,
+				29C30D0121079D2100DF237F /* QRCode.swift in Sources */,
 				51A5205D1FE33B04003F6EC7 /* WebViewController.swift in Sources */,
 				5148279C1FEDAF0C00C788E3 /* SubscriptionTransaction.swift in Sources */,
 				51A8907720646C1900BBA280 /* UILabel+Extensions.swift in Sources */,

--- a/Raiblocks/Models/QRCode.swift
+++ b/Raiblocks/Models/QRCode.swift
@@ -1,0 +1,23 @@
+//
+//  QRCode.swift
+//  Raiblocks
+//
+//  Created by Fawaz Tahir on 7/24/18.
+//  Copyright © 2018 Zack Shapiro. All rights reserved.
+//
+
+import Foundation
+
+struct QRCode {
+    
+    let address: Address
+    let amount: NSDecimalNumber?
+    
+    init?(address string: String) {
+        guard let parsedAddress = AddressParser.parse(string: string) else {
+            return nil
+        }
+        self.address = parsedAddress.address
+        self.amount = parsedAddress.amount
+    }
+}

--- a/Raiblocks/SendViewController/AddressParser.swift
+++ b/Raiblocks/SendViewController/AddressParser.swift
@@ -8,29 +8,31 @@
 
 final class AddressParser {
 
-    static func parse(string: String) -> (address: Address, amount: NSDecimalNumber)? {
-        if string.contains(":") {
-            let _addressString = string.split(separator: ":")[1]
-            let addressString = _addressString.split(separator: "?")[0]
-
-            guard let address = Address(String(addressString)) else { return nil }
-
-            var amount: NSDecimalNumber = 0
-            if String(_addressString).contains("amount=") {
-                // TODO: protect against strings formatted as 1,000.00
-                let values = _addressString.split(separator: "=")
-
-                guard values.count > 1 else { return (address: address, amount: 0) }
-                let val = values[1].replacingOccurrences(of: ",", with: ".")
-                amount = NSDecimalNumber(string: val)
-            }
-
-            return (address: address, amount: amount)
-        } else {
-            guard let address = Address(string) else { return nil }
-
-            return (address: address, amount: 0)
+    static func parse(string: String) -> (address: Address, amount: NSDecimalNumber?)? {
+        if let address = Address(string) {
+            return (address: address, amount: nil)
         }
+        
+        guard string.contains(":") else {
+            return nil
+        }
+        
+        let _addressString = string.split(separator: ":")[1]
+        let addressString = _addressString.split(separator: "?")[0]
+        
+        guard let address = Address(String(addressString)) else { return nil }
+        
+        var amount: NSDecimalNumber = 0
+        if String(_addressString).contains("amount=") {
+            // TODO: protect against strings formatted as 1,000.00
+            let values = _addressString.split(separator: "=")
+            
+            guard values.count > 1 else { return (address: address, amount: 0) }
+            let val = values[1].replacingOccurrences(of: ",", with: ".")
+            amount = NSDecimalNumber(string: val)
+        }
+        
+        return (address: address, amount: amount)
     }
 
 }

--- a/Raiblocks/SendViewController/AddressParser.swift
+++ b/Raiblocks/SendViewController/AddressParser.swift
@@ -22,12 +22,12 @@ final class AddressParser {
         
         guard let address = Address(String(addressString)) else { return nil }
         
-        var amount: NSDecimalNumber = 0
+        var amount: NSDecimalNumber? = nil
         if String(_addressString).contains("amount=") {
             // TODO: protect against strings formatted as 1,000.00
             let values = _addressString.split(separator: "=")
             
-            guard values.count > 1 else { return (address: address, amount: 0) }
+            guard values.count > 1 else { return (address: address, amount: nil) }
             let val = values[1].replacingOccurrences(of: ",", with: ".")
             amount = NSDecimalNumber(string: val)
         }

--- a/Raiblocks/SendViewController/CodeScanViewController.swift
+++ b/Raiblocks/SendViewController/CodeScanViewController.swift
@@ -13,7 +13,7 @@ import ReactiveSwift
 
 
 @objc protocol CodeScanViewControllerDelegate: class {
-    func didReceiveAddress(address: Address, amount: NSDecimalNumber)
+    func didReceive(address: String)
 }
 
 
@@ -58,13 +58,7 @@ final class CodeScanViewController: ScannerViewContoller {
     private func scanAddress() {
         scannerCameraView?.qrCodeProducer()
             .startWithValues { string in
-                if let address = Address(string) {
-                    self.delegate?.didReceiveAddress(address: address, amount: 0)
-                } else if let parsedAddress = AddressParser.parse(string: string) {
-                    self.delegate?.didReceiveAddress(address: parsedAddress.address, amount: parsedAddress.amount)
-                } else {
-                    AnalyticsEvent.errorParsingQRCode.track(customAttributes: ["qr_code_string": string])
-                }
+                self.delegate?.didReceive(address: string)
             }
     }
 

--- a/Raiblocks/SendViewController/SendViewController.swift
+++ b/Raiblocks/SendViewController/SendViewController.swift
@@ -612,25 +612,14 @@ extension SendViewController: CodeScanViewControllerDelegate {
         self.addressTextView?.togglePlaceholder(show: false)
         self.addressTextView?.attributedText = addAttributes(forAttributedText: address.longAddressWithColor)
 
-        switch amount.compare(0) {
-        case .orderedSame, .orderedAscending:
-            navigationController?.dismiss(animated: true) {
-                self.nanoTextField?.becomeFirstResponder()
+        navigationController?.dismiss(animated: true) { [weak self] in
+            switch amount.compare(0) {
+            case .orderedSame, .orderedAscending: break
+            case .orderedDescending:
+                self?.viewModel.nanoAmount.value = amount
+                self?.nanoTextField?.text = amount.stringValue
             }
-
-        case .orderedDescending:
-            if amount.asRawValue.compare(viewModel.sendableNanoBalance) == .orderedDescending {
-                navigationController?.dismiss(animated: true) {
-                    self.nanoTextField?.becomeFirstResponder()
-                }
-            } else {
-                navigationController?.dismiss(animated: true) {
-                    self.sendableAmountIsValid.value = true
-
-                    self.viewModel.nanoAmount.value = amount
-                    self.nanoTextField?.text = amount.stringValue
-                }
-            }
+            self?.nanoTextField?.becomeFirstResponder()
         }
     }
 


### PR DESCRIPTION
Addresses https://github.com/nano-wallet-company/nano-wallet-ios/issues/21

1. The send amount in the QR code no longer needs to be greater than (or equal to) the sendable balance. The Send button continues to remain disabled if the amount is an invalid send amount.
2. No longer capturing `self` upon dismissal.
3. Decoupled `CodeScanViewController` from `Address` and `AddressParser`.
4. Added a model for `QRCode` and moved logic from view controller into
the model. Logic is now isolated and more testable.

@zackshapiro I'm unsure what the reasoning was behind having the balance check. We'd have to check with the designer on the UX, and if it makes sense to allow the field to have an invalid send amount. 

We can close this pull request if this turns out to be a not-a-bug, or on the contrary, I can add tests for this change and merge it.