### PR TITLE
Incorrect Send Amount

### DIFF
--- a/Raiblocks/HomeViewController/HomeViewController.swift
+++ b/Raiblocks/HomeViewController/HomeViewController.swift
@@ -242,7 +242,11 @@ class HomeViewController: UIViewController {
     @objc func sendNano() {
         viewModel.isCurrentlySending.value = true
 
-        let vc = SendViewController(viewModel: SendViewModel(homeSocket: self.viewModel.socket))
+        let homeSocket = self.viewModel.socket
+        let initialSendableBalance = viewModel.transactableAccountBalance.value
+        let sendViewModel = SendViewModel(homeSocket: homeSocket, initialSendableBalance: initialSendableBalance)
+        
+        let vc = SendViewController(viewModel: sendViewModel)
         vc.delegate = self
 
         self.navigationController?.pushViewController(vc, animated: true)
@@ -355,7 +359,13 @@ extension HomeViewController: UITableViewDelegate {
     private func showExplorerAlert(forIndexPath indexPath: IndexPath) {
         let ac = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
         ac.addAction(UIAlertAction(title: "Send Nano to Address", style: .default) { _ in
-            let vc = SendViewController(viewModel: SendViewModel(homeSocket: self.viewModel.socket, toAddress: self.viewModel.transactions.value[indexPath.row].fromAddress))
+            let homeSocket = self.viewModel.socket
+            let sendAddress = self.viewModel.transactions.value[indexPath.row].fromAddress
+            let initialSendableBalance = self.viewModel.transactableAccountBalance.value
+            let sendViewModel = SendViewModel(homeSocket: homeSocket,
+                                              toAddress: sendAddress,
+                                              initialSendableBalance: initialSendableBalance)
+            let vc = SendViewController(viewModel: sendViewModel)
             vc.delegate = self
 
             self.navigationController?.pushViewController(vc, animated: true)

--- a/Raiblocks/SendViewController/SendViewModel.swift
+++ b/Raiblocks/SendViewController/SendViewModel.swift
@@ -14,7 +14,7 @@ import SwiftWebSocket
 
 final class SendViewModel {
 
-    var sendableNanoBalance: NSDecimalNumber = 0
+    private(set) var sendableNanoBalance: NSDecimalNumber
     var previousFrontierHash: String?
 
     let socket: WebSocket
@@ -73,9 +73,10 @@ final class SendViewModel {
         }
     }
 
-    init(homeSocket socket: WebSocket, toAddress: Address? = nil) {
+    init(homeSocket socket: WebSocket, toAddress: Address? = nil, initialSendableBalance: NSDecimalNumber) {
         self.socket = socket
         self.toAddress = toAddress
+        self.sendableNanoBalance = initialSendableBalance
 
         self.localCurrency = priceService.localCurrency.value
         self.groupingSeparator = localCurrency.locale.groupingSeparator ?? ","


### PR DESCRIPTION
We're now passing along an initial value for the `sendableNanoBalance` when creating a `SendViewModel`. This ensures a non-zero value for the `sendableNanoBalance`, upon which assumption the `SendViewController` relies. There was a case where if the user had a slow internet connection and we were not able to retrieve the `sendableNanoBalance` in time before the user entered a value, the view controller would set the balance to the maximum amount by comparing it to the default value of `sendableNanoBalance` of `0`.